### PR TITLE
fix update dots to screen during runtime

### DIFF
--- a/ssllabs/__init__.py
+++ b/ssllabs/__init__.py
@@ -342,8 +342,8 @@ class SSLLabsAssessment(object):
                 _host_status = _status.get('status')
                 if _host_status == 'IN_PROGRESS':
                     if logging.getLogger().getEffectiveLevel() <= 20:
-                        sys.stdout.write('.')
-                        sys.stdout.flush()
+                        sys.stderr.write('.')
+                        sys.stderr.flush()
                     time.sleep(10)
                 elif _host_status == 'READY':
                     return _status if self.return_all in ('on', 'done') else self._get_all_results()


### PR DESCRIPTION
status updates via "." to screen goto stdout. these should go to stderr to avoid polluting the json output.

```
diff bad.json good.json
1c1
< .......{
---
> {
```
